### PR TITLE
py3 port (#1)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [py3-port]   # or - py3-port
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'      # pulls pytest + tox (from setup.py extras)
+
+      - name: Run pytest
+        run: python -m pytest -q

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 Changelog
 =========
-:Version: 1.0.3 of 2025-08-02
+:Version: 2.0.0 of 2025-08-02
 
 Support for Python 3.8+
 Added calibrate_tim2_day function to batch.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Changelog
 =========
+:Version: 1.0.3 of 2025-08-02
 
+Support for Python 3.8+
+Added calibrate_tim2_day function to batch.py
 
 :Version: 1.0.2 of 2017-09-29
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Installation
 Dependencies (automatically installed)
 --------------------------------------
 
-    - Python 2.7
+    - Python 3.8+
     - NumPy
     - SciPy
     - Pandas

--- a/priceprop/__init__.py
+++ b/priceprop/__init__.py
@@ -1,6 +1,6 @@
 from .propagator import *
 
-__version__ = "1.0.3"
+__version__ = "2.0.0"
 
 
 def __reload_submodules__():

--- a/priceprop/__init__.py
+++ b/priceprop/__init__.py
@@ -1,4 +1,7 @@
-from propagator import *
+from .propagator import *
+
+__version__ = "1.0.3"
+
 
 def __reload_submodules__():
     reload(propagator)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='priceprop',
-    version='1.0.3',
+    version='2.0.0',
     description=(
         'Calibrate and simulate linear propagator models for the price '
         'impact of an extrinsic order flow.'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='priceprop',
-    version='1.0.2',
+    version='1.0.3',
     description=(
         'Calibrate and simulate linear propagator models for the price '
         'impact of an extrinsic order flow.'
@@ -15,19 +15,22 @@ setup(
             Journal of Statistical Mechanics (2017, in print)
             Preprint at arXiv:1706.04163
     """,
+    python_requires='>=3.8',
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2 :: Only',
-        'Programming Language :: Python :: 2.7',
-        #'Programming Language :: Python :: 3',
-        #'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering',
         'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3 :: 8",
+        "Programming Language :: Python :: 3 :: 9",
+        "Programming Language :: Python :: 3 :: 10",
+        "Programming Language :: Python :: 3 :: 11"
     ],
     keywords=[
         'propagator', 'price impact', 'intra day', 'order flow', 
@@ -36,19 +39,20 @@ setup(
     ],
     url='http://github.com/felixpatzelt/priceprop',
     download_url=(
-      'https://github.com/felixpatzelt/priceprop/archive/1.0.2.tar.gz'
+      'https://github.com/felixpatzelt/priceprop/archive/1.0.3.tar.gz'
     ),
     author='Felix Patzelt',
     author_email='felix@neuro.uni-bremen.de',
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'numpy',
-        'scipy',
-        'pandas',
-        'scorr'
+        "numpy>=1.24", 
+        "scipy>=1.10", 
+        "pandas>=2.0", 
+        "scorr @ git+https://github.com/robatobalzac/scorr.git"
     ],
     include_package_data=True,
     zip_safe=False,
     test_suite='tests',
+    extras_require={'dev': ['pytest>=8', 'tox>=4']}
 )

--- a/tests/test_propagator.py
+++ b/tests/test_propagator.py
@@ -107,7 +107,7 @@ class TestHDIM2(unittest.TestCase):
             lpars = {
                 k: np.array(v) if hasattr(v, '__len__') 
                 else v 
-                for k,v in json.load(f).iteritems()
+                for k,v in json.load(f).items()
             }
         kn_est, kc_est = prop.calibrate_hdim2(
             lpars['Cnnc'], 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py311, py310, py39, py38
+
+[testenv]
+deps = pytest
+usedevelop = true          # install package in editable mode instead of sdist
+changedir = {toxinidir}    # run tests in the repo root
+commands = pytest -q


### PR DESCRIPTION
* Green test-suite on Python 3: slice & dict fixes

* Amending tox test conditions

* adding ci.yaml

* added full docstrings

* correting ci.yaml syntax error

* py3-port: make batch.py import relative, drop Py2 refs, bump to v1.0.3

* batch: restore calibrate_tim2_day convenience wrapper

* batch: split concatenated kernel so helper returns (G_pc, G_npc, meta)

* batch: changelog update